### PR TITLE
Modal - clickOutside option update

### DIFF
--- a/resources/frontend/scripts/behaviors/Modal.js
+++ b/resources/frontend/scripts/behaviors/Modal.js
@@ -71,20 +71,12 @@ const Modal = createBehavior(
             }
         },
         handleClickOutside(e) {
-            if (this._data.isActive) {
+            if (this._data.isActive && !this.$focusTrap.contains(e.target)) {
                 this.close(e)
             }
         },
-        handleCloseInside(e) {
-            e.stopPropagation()
-        },
         registerOpenEvents() {
             if (this.$clickOutside) {
-                this.$focusTrap.addEventListener(
-                    'click',
-                    this.handleCloseInside,
-                    false
-                )
                 document.addEventListener(
                     'click',
                     this.handleClickOutside,


### PR DESCRIPTION
Modal - Remove handleCloseInside event that was making swupJs links inside modal buggy because of the stopPropagation that is too aggressive.

This change dont interfer with clicks event happening into the modal