### PR TITLE
Modal - Add possibility to set multiple behaviors on modal elements

### DIFF
--- a/resources/views/components/modal/modal.blade.php
+++ b/resources/views/components/modal/modal.blade.php
@@ -5,9 +5,9 @@
          role="dialog"
          aria-labelledby="{{ $id . '_title' }}"
          aria-modal="true"
+         {{ $attributes->merge(['data-behavior' => $attributes->prepends('Modal')])->twMerge($ui('modal', ['base'])) }}
          {!! $panel ? 'data-Modal-panel="true"' : '' !!}
-         {!! $clickOutsideToClose ? 'data-Modal-clickOutside="true"' : '' !!}
-         {{ $attributes->twMerge($ui('modal', ['base'])) }}>
+         {!! $clickOutsideToClose ? 'data-Modal-clickOutside="true"' : '' !!}>
         <div class="{{ $ui('modal', '', ['wrapper' => $variant]) }}"
              data-Modal-focus-trap
              tabindex="-1">

--- a/resources/views/components/modal/modal.blade.php
+++ b/resources/views/components/modal/modal.blade.php
@@ -1,7 +1,6 @@
 @push($modalsStack)
 
     <div id="{{ $id }}"
-         data-behavior="Modal"
          role="dialog"
          aria-labelledby="{{ $id . '_title' }}"
          aria-modal="true"


### PR DESCRIPTION
This unlock the possibility to attach behavior that are listening open/close event of the modal to handle internal logic.

In a secondary behavior :

```
            this.$node.addEventListener(
                customEvents.MODAL_NODE_OPENED,
                this.openedModal,
                false
            )

            this.$node.addEventListener(
                customEvents.MODAL_NODE_CLOSED,
                this.closedModal,
                false
            )
```