### PR TITLE
Modal - close event from destroy

### DIFF
--- a/resources/frontend/scripts/behaviors/Modal.js
+++ b/resources/frontend/scripts/behaviors/Modal.js
@@ -26,7 +26,9 @@ const Modal = createBehavior(
                 this._data.isActive = false
 
                 setTimeout(() => {
-                    enableBodyScroll(this.$scroller)
+                    if (this.$scroller) {
+                        enableBodyScroll(this.$scroller)
+                    }
                 }, 200)
 
                 this.$node.dispatchEvent(


### PR DESCRIPTION
Bugfix : Check if scroller exist to avoid issues when called from destroy method when navigating from page to page