### PR TITLE
Accordion exclusive - Destroy throw error

### DIFF
--- a/resources/frontend/scripts/behaviors/Accordion.js
+++ b/resources/frontend/scripts/behaviors/Accordion.js
@@ -23,17 +23,21 @@ const Accordion = createBehavior(
             // exclusive mode : close other opened accordion items
             if (this.exclusive) {
                 setTimeout(() => {
-                    this.$triggers.forEach((trigger) => {
-                        const triggerIndex = this.getTriggerIndex(trigger)
+                    if (this.$triggers) {
+                        this.$triggers.forEach((trigger) => {
+                            const triggerIndex = this.getTriggerIndex(trigger)
 
-                        // closed opened accordion items
-                        if (
-                            this._data.activeIndexes.includes(triggerIndex) &&
-                            triggerIndex !== index
-                        ) {
-                            this.triggerClose(triggerIndex)
-                        }
-                    })
+                            // closed opened accordion items
+                            if (
+                                this._data.activeIndexes.includes(
+                                    triggerIndex
+                                ) &&
+                                triggerIndex !== index
+                            ) {
+                                this.triggerClose(triggerIndex)
+                            }
+                        })
+                    }
                 }, TIMEOUT + 1)
             }
         },


### PR DESCRIPTION
Accordion exclusive - fix issue raised when accordion is being destroyed : triggers is missing because it has been removed from the DOM