### PR TITLE
Button - Add scoped slots for before/after content

### DIFF
--- a/resources/views/components/button/default.blade.php
+++ b/resources/views/components/button/default.blade.php
@@ -1,3 +1,8 @@
+@props([
+    'slotBefore' => null,
+    'slotAfter' => null,
+])
+
 <{{ $tag }} {{ $attributes->twMerge(
     $ui($uiKeyComponent, 'base', [
         'size' => $size,
@@ -8,6 +13,9 @@
 ) }}
                      @if ($href) href="{{ $href }}" @endif
                      @if ($target) target="{{ $target }}" @endif>
+    @if ($slotBefore)
+        {{ $slotBefore }}
+    @endif
 
     @if ($iconBefore())
         <x-vui-icon class="{{ $ui($uiKeyComponent, 'icon') }}"
@@ -21,5 +29,9 @@
     @if ($iconAfter())
         <x-vui-icon class="{{ $ui($uiKeyComponent, 'icon') }}"
                     :name="$icon" />
+    @endif
+
+    @if ($slotAfter)
+        {{ $slotAfter }}
     @endif
     </{{ $tag }}>

--- a/resources/views/stories/button/README.md
+++ b/resources/views/stories/button/README.md
@@ -19,6 +19,21 @@ The default component slot is used for the label text within the button. It can 
 </x-vui-button>
 ```
 
+Additional scoped slots are available to add extra markup before or after the label :
+
+```html
+<x-vui-button href="https://example.url">
+    <x-slot:slotBefore>
+        <span>BEFORE CONTENT</span>
+    </x-slot:slotBefore>
+    <x-slot:slotAfter>
+        <span>AFTER CONTENT</span>
+    </x-slot:slotAfter>
+
+    Label Text
+</x-vui-button>
+```
+
 ## Accessibility
 
 Buttons should always have an accessible name. For most buttons this will be the label text but for buttons without label text they should have an `aria-label` or `aria-labelledby` attribute.

--- a/resources/views/stories/button/slots.blade.php
+++ b/resources/views/stories/button/slots.blade.php
@@ -1,0 +1,21 @@
+@storybook([
+    'status' => 'readyForQA',
+    'preset' => 'button.base',
+])
+
+<x-vui-button :href="$href ?? null"
+              :icon="$icon ?? null"
+              :icon-position="$iconPosition ?? null"
+              :static="$static ?? null"
+              :disabled="$disabled ?? null"
+              :active="$active ?? null"
+              variant="secondary">
+    <x-slot:slotBefore>
+        <span>BEFORE CONTENT</span>
+    </x-slot:slotBefore>
+    <x-slot:slotAfter>
+        <span>AFTER CONTENT</span>
+    </x-slot:slotAfter>
+
+    {{ $label ?? null }}
+</x-vui-button>


### PR DESCRIPTION
Usage :

```html
<x-vui-button href="https://example.url">
    <x-slot:slotBefore>
        <span>BEFORE CONTENT</span>
    </x-slot:slotBefore>
    <x-slot:slotAfter>
        <span>AFTER CONTENT</span>
    </x-slot:slotAfter>

    Label Text
</x-vui-button>
```