### PR TITLE
Fix incorrect html for accordion, checkbox, radio and pagination

### DIFF
--- a/resources/views/components/accordion/item.blade.php
+++ b/resources/views/components/accordion/item.blade.php
@@ -31,7 +31,7 @@
                 {{ $slotTrigger }}
             @else
                 <span class="{{ VitrineUI::ui('accordion-item', 'title', [], $ui ?? []) }}">{{ $title }}</span>
-                <div class="{{ VitrineUI::ui('accordion-item', 'icons', [], $ui ?? []) }}">
+                <span class="{{ VitrineUI::ui('accordion-item', 'icons', [], $ui ?? []) }}">
                     @if ($iconClosed ?? false)
                         <x-vui-icon class="{{ VitrineUI::ui('accordion-item', ['icon', 'icon-close'], [], $ui ?? []) }}"
                                     :name="$iconClosed" />
@@ -40,7 +40,7 @@
                         <x-vui-icon class="{{ VitrineUI::ui('accordion-item', ['icon', 'icon-open'], [], $ui ?? []) }}"
                                     :name="$iconOpen" />
                     @endif
-                </div>
+                </span>
             @endif
         </button>
     </x-vui-heading>

--- a/resources/views/components/form/checkbox/checkbox.blade.php
+++ b/resources/views/components/form/checkbox/checkbox.blade.php
@@ -33,7 +33,7 @@
      {{ $disabled ? 'inert' : '' }}>
     <label class="{{ $ui('checkbox', 'base') }}"
            @if ($id || $name) for="{{ $id ? $id : $name . $rand }}" @endif>
-        <div class="{{ $ui('checkbox', 'wrapper') }}">
+        <span class="{{ $ui('checkbox', 'wrapper') }}">
             <input class="{{ $ui('checkbox', 'input') }}"
                    data-Input-input
                    type="checkbox"
@@ -64,7 +64,7 @@
                 <span class="{{ $ui('checkbox', 'hint') }}"
                       id="{{ $ariaID }}Hint">{{ $hint }}</span>
             @endif
-        </div>
+        </span>
     </label>
     <p class="{{ $ui('input', 'error') }}"
        id="{{ $errorID }}"

--- a/resources/views/components/form/radio/radio.blade.php
+++ b/resources/views/components/form/radio/radio.blade.php
@@ -32,7 +32,7 @@
      {{ $disabled ? 'inert' : '' }}>
     <label class="{{ $ui('radio', 'base') }}"
            @if ($id || $name) for="{{ $id ? $id : $name . $rand }}" @endif>
-        <div class="{{ $ui('radio', 'wrapper') }}">
+        <span class="{{ $ui('radio', 'wrapper') }}">
             <input class="{{ $ui('radio', 'input') }}"
                    data-Input-input
                    type="radio"
@@ -55,7 +55,7 @@
                 <span class="{{ $ui('radio', 'hint') }}"
                       id="{{ $ariaID }}Hint">{{ $hint }}</span>
             @endif
-        </div>
+        </span>
     </label>
     <p class="{{ $ui('input', 'error') }}"
        id="{{ $errorID }}"

--- a/resources/views/components/pagination/pagination.blade.php
+++ b/resources/views/components/pagination/pagination.blade.php
@@ -13,7 +13,7 @@
             <x-vui-button class="{{ Arr::toCssClasses([
                 $ui('pagination', 'action-disabled') => $onFirstPage,
             ]) }}"
-                          aria-label="{{ __('vitrine-ui::fe.pagination.previous') }}"
+                          :aria-label="$onFirstPage ? null : __('vitrine-ui::fe.pagination.previous')"
                           :href="$prevPageUrl()"
                           :variant="$btnVariant ?? 'secondary'"
                           :icon="$iconLeft ?? 'arrow-left-24'"
@@ -25,7 +25,7 @@
             <x-vui-button class="{{ Arr::toCssClasses([
                 $ui('pagination', 'action-disabled') => $onLastPage,
             ]) }}"
-                          aria-label="{{ __('vitrine-ui::fe.pagination.next') }}"
+                          :aria-label="$onLastPage ? null : __('vitrine-ui::fe.pagination.next')"
                           :href="$nextPageUrl()"
                           :icon="$iconRight ?? 'arrow-right-24'"
                           :variant="$btnVariant ?? 'secondary'"


### PR DESCRIPTION
- Update some `div` to `span` as they are already inside a `span`
- Only use `aria-label` on pagination buttons when they are a `button` and not `span`